### PR TITLE
本番環境向けのパスワードリセットメールを送信する設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,9 @@ gem 'dartsass-sprockets'
 # JSランタイムgem
 gem 'mini_racer'
 
+# 環境変数を自動認識させるgem
+gem 'dotenv-rails'
+
 gem 'sorcery'
 
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     deep_merge (1.2.2)
+    dotenv (3.0.2)
+    dotenv-rails (3.0.2)
+      dotenv (= 3.0.2)
+      railties (>= 6.1)
     drb (2.2.0)
       ruby2_keywords
     dry-configurable (1.1.0)
@@ -385,6 +389,7 @@ DEPENDENCIES
   config
   dartsass-sprockets
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   jquery-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module RailsApp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
 
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost:3000', protocol: 'http' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,24 +71,26 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "rails_app_production"
 
+  # herokuデプロイURL
   host = 'debate-discord-bbs-b5c63f29db06.herokuapp.com'
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host, protocol: 'https' }
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
 
   ActionMailer::Base.smtp_settings = {
-    :port           => 587,
-    :address        => 'smtp.mailgun.org',
-    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
-    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => host,
-    :authentication => :plain,
+    port: 587,
+    address: 'smtp.gmail.com',
+    domain: 'gmail.com', #Gmailを使う場合
+    user_name: ENV['GMAIL_ADDRESS'], #Gmailアカウントのメールアドレス
+    password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,20 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "rails_app_production"
 
+  host = 'debate-discord-bbs-b5c63f29db06.herokuapp.com'
+
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host, protocol: 'https' }
+
+  ActionMailer::Base.smtp_settings = {
+    :port           => 587,
+    :address        => 'smtp.mailgun.org',
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => host,
+    :authentication => :plain,
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -30,4 +30,3 @@ ja:
       role:
         general: 一般
         admin: 管理者
-

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,0 @@
-default_url_options:
-  host: 'localhost:3000'


### PR DESCRIPTION
gem configを使って定義してみたものの、
コンソールから確認してみるとうまくプロパティの呼び出しが出来ていないようだったので、
念の為configではなく各environmentsファイルに直接定義しました。

それに伴い環境変数とそれを自動認識してくれるgemを追加

