### PR TITLE
heroku.ymlファイルの追加

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
herokuデプロイが失敗し続けており、
ログにはアプリケーションクラッシュが残っていたため原因を調べていたところ、
dockerを利用している場合はheroku.ymlファイルが必要とのドキュメントを発見

Dockerを作る部分までしか目を通せていなかったので、単純に作り忘れていた事が原因のようなので、
まずはテキスト通りに作って様子を見ます。